### PR TITLE
コレクションのかわりに配列を返す

### DIFF
--- a/app/Http/Controllers/SentenceController.php
+++ b/app/Http/Controllers/SentenceController.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Facades\Validator;
 
 class SentenceController extends Controller
 {
-    const SECRET_FALSE_KEYWORD = 'false'; // 認証解除用のキーワード
     /**
      * Display a listing of the resource.
      */
@@ -159,6 +158,6 @@ class SentenceController extends Controller
             return true;
         });
 
-        return $sentences;
+        return $sentences->values()->all();
     }
 }


### PR DESCRIPTION
文章を返す場合、いままではコレクションを渡していたが、配列を返すようにした。